### PR TITLE
Fixed #41. 

### DIFF
--- a/R/create_table_4_4_to_4_6.R
+++ b/R/create_table_4_4_to_4_6.R
@@ -33,6 +33,10 @@ create_t4.4_to_4_6 <- function(data, data_year = NA, col_var = fert_age_grp, by_
     data_year = data %>% pull(!!sym(date_var)) %>% max(na.rm = TRUE)
   }
 
+  # Ensure data for fer_age_group is handled as a straight string, not a factor
+  # Avoids issues with fert_age_grp
+  data$fert_age_grp <- as.character(data$fert_age_grp)
+
   if(rural_urban == "no"){
     output <- data |>
       filter(doryr == data_year & is.na(birth1j)) |>


### PR DESCRIPTION
# Description

Tables 4_4 to 4_6 did not output correct fertility age groups. Updated tests to use externally sourced synth data. Revised create_table_4_4_to_4_6 to handle factors in fert_age_grp. Fixes #41 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style and contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Issue this pull request resolves

#41 
